### PR TITLE
fix: check if WooCommerce is activated before loading DePay

### DIFF
--- a/includes/class-depay-wc-payments.php
+++ b/includes/class-depay-wc-payments.php
@@ -11,6 +11,10 @@ class DePay_WC_Payments {
 
 		define( 'DEPAY_VERSION_NUMBER', self::get_plugin_headers()['Version'] );
 
+		if ( !class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
 		include_once DEPAY_WC_ABSPATH . 'includes/class-depay-wc-payments-gateway.php';
 		include_once DEPAY_WC_ABSPATH . 'includes/class-depay-wc-payments-settings.php';
 		include_once DEPAY_WC_ABSPATH . 'includes/class-depay-wc-payments-admin.php';


### PR DESCRIPTION
This patch makes sure to check if WooCommerce is activated before continuing to load the rest of the DePay Payments plugin, which relies on WooCommerce being activated and would raise an exception otherwise.